### PR TITLE
Allow native coroutines to be test functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: python
 python:
     - 2.7
     - 3.4
+    - 3.5
 env:
+    - TORNADO_VERSION=4.3 PYTEST_VERSION=2.8.6
+    - TORNADO_VERSION=4.1 PYTEST_VERSION=2.8.6
     - TORNADO_VERSION=4.1 PYTEST_VERSION=2.7.0
     - TORNADO_VERSION=4.1 PYTEST_VERSION=2.6.4
     - TORNADO_VERSION=3.2.2 PYTEST_VERSION=2.6.4
@@ -11,6 +14,18 @@ install:
     - pip install -q tornado==$TORNADO_VERSION pytest==$PYTEST_VERSION
     - python setup.py install
     - pip install pytest-cov coveralls
+matrix:
+  exclude:
+    - python: 3.5
+      env: TORNADO_VERSION=3.2.2 PYTEST_VERSION=2.6.4
+    - python: 3.5
+      env: TORNADO_VERSION=3.2.2 PYTEST_VERSION=2.5.2
+    - python: 3.5
+      env: TORNADO_VERSION=4.1 PYTEST_VERSION=2.6.4
+    - python: 3.5
+      env: TORNADO_VERSION=4.1 PYTEST_VERSION=2.5.2
+    - python: 3.5
+      env: TORNADO_VERSION=4.1 PYTEST_VERSION=2.7.0
 script:
     - py.test --strict --cov=pytest_tornado/plugin.py --cov-report=term-missing
 after_success:

--- a/pytest_tornado/test/conftest.py
+++ b/pytest_tornado/test/conftest.py
@@ -1,0 +1,6 @@
+import sys
+import tornado
+
+collect_ignore = []
+if sys.version_info[:2] < (3, 5) or tornado.version_info[:2] < (4, 3):
+    collect_ignore.append("test_async_await.py")

--- a/pytest_tornado/test/test_async.py
+++ b/pytest_tornado/test/test_async.py
@@ -1,5 +1,6 @@
 import functools
 import pytest
+import tornado
 from tornado import gen
 from tornado.ioloop import TimeoutError
 
@@ -30,6 +31,12 @@ def test_gen_test_sync(io_loop):
 
 @pytest.mark.gen_test
 def test_gen_test(io_loop):
+    result = yield dummy_coroutine(io_loop)
+    assert result
+
+
+@pytest.mark.gen_test(run_sync=False)
+def test_gen_test_run_sync_false(io_loop):
     result = yield dummy_coroutine(io_loop)
     assert result
 

--- a/pytest_tornado/test/test_async_await.py
+++ b/pytest_tornado/test/test_async_await.py
@@ -1,0 +1,18 @@
+import pytest
+from tornado import gen
+
+async def dummy_native_coroutine(io_loop):
+    await gen.Task(io_loop.add_callback)
+    return True
+
+
+@pytest.mark.gen_test
+async def test_native_coroutine_gen_test(io_loop):
+    result = await dummy_native_coroutine(io_loop)
+    assert result
+
+
+@pytest.mark.gen_test(run_sync=False)
+async def test_native_coroutine_run_sync_false(io_loop):
+    result = await dummy_native_coroutine(io_loop)
+    assert result


### PR DESCRIPTION
This will allow to write tests using new async def/await syntax.

References:
* Original problem that tornado.gen.coroutine does not work properly with native coroutines seen here https://github.com/tornadoweb/tornado/pull/1550
* Similar pull request for pytest-asyncio https://github.com/pytest-dev/pytest-asyncio/pull/17
* How to exclude python3.5 specific tests https://github.com/pytest-dev/pytest-asyncio/commit/67ab432978bcf0f67293c2fbc8d3fce6d141de04