### PR TITLE
Allow configuring the value of `async_test_timeout` as a fixture

### DIFF
--- a/pytest_tornado/test/test_async.py
+++ b/pytest_tornado/test/test_async.py
@@ -98,6 +98,7 @@ class TestClass:
             1 / 0
 
 
+@pytest.mark.skipif(tornado.version_info < (4, 1), reason='These tests will fail on Tornado < 4.1')
 @pytest.mark.gen_test
 def test_timeout_as_fixture(testdir):
     testdir.makepyfile(
@@ -121,6 +122,7 @@ def test_timeout_as_fixture(testdir):
     ])
 
 
+@pytest.mark.skipif(tornado.version_info < (4, 1), reason='These tests will fail on Tornado < 4.1')
 @pytest.mark.gen_test
 def test_gen_test_timeout_overrides_timeout_fixture(testdir):
     testdir.makepyfile(

--- a/pytest_tornado/test/test_async.py
+++ b/pytest_tornado/test/test_async.py
@@ -117,7 +117,7 @@ def test_timeout_as_fixture(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        '*tornado.ioloop.TimeoutError: Operation timed out after 0.1 seconds',
+        '*TimeoutError: Operation timed out after 0.1 seconds',
     ])
 
 
@@ -140,5 +140,5 @@ def test_gen_test_timeout_overrides_timeout_fixture(testdir):
 
     # fnmatch_lines does an assertion internally
     result.stdout.fnmatch_lines([
-        '*tornado.ioloop.TimeoutError: Operation timed out after 0.1 seconds',
+        '*TimeoutError: Operation timed out after 0.1 seconds',
     ])


### PR DESCRIPTION
This will allow to, for example, increase the timeout for all tests on a
test module which are known to run slower but not increase the timeout
globally and without requiring to pass timeout to all `gen_test` markers.
