### PR TITLE
Fixed missing support for type annotated test functions

### DIFF
--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -59,7 +59,10 @@ def pytest_configure(config):
 
 
 def _argnames(func):
-    spec = inspect.getargspec(func)
+    if sys.version_info[0] == 3:
+        spec = inspect.getfullargspec(func)
+    else:
+        spec = inspect.getargspec(func)
     if spec.defaults:
         return spec.args[:-len(spec.defaults)]
     if isinstance(func, types.FunctionType):


### PR DESCRIPTION
This fixes an issue when you try to annotate types of your test function parameters; e.g.:

```
@pytest.mark.gen_test
async def test_hello_world(http_client: AsyncHTTPClient):
    response = await http_client.fetch('/')
    assert response.code == 200
```

The above code will raise a _ValueError_:
`ValueError: Function has keyword-only parameters or annotations, use getfullargspec() API which can support them`