### PR TITLE
Use inspect.signature

### DIFF
--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -59,13 +59,8 @@ def pytest_configure(config):
 
 
 def _argnames(func):
-    spec = inspect.getargspec(func)
-    if spec.defaults:
-        return spec.args[:-len(spec.defaults)]
-    if isinstance(func, types.FunctionType):
-        return spec.args
-    # Func is a bound method, skip "self"
-    return spec.args[1:]
+    sig = inspect.signature(func)
+    return [name for name, param in sig.parameters.items() if param.default is param.empty]
 
 
 def _timeout(item):


### PR DESCRIPTION
inspect.getargspec is deprecated. _argnames now uses inspect.signature.
This commit also changes the behaviour to be more consistent. The
previous commit would strip self from the arguments, but only when no
default arguments were passed.

This PR fixes #23 