### PR TITLE
Fix to work with tornado 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ python:
     - 2.7
     - 3.4
     - 3.5
+    - 3.6
 env:
+    - TORNADO_VERSION=5.0 PYTEST_VERSION=3.4.2
     - TORNADO_VERSION=4.3 PYTEST_VERSION=2.8.6
     - TORNADO_VERSION=4.1 PYTEST_VERSION=2.8.6
     - TORNADO_VERSION=4.1 PYTEST_VERSION=2.7.0
     - TORNADO_VERSION=4.1 PYTEST_VERSION=2.6.4
-    - TORNADO_VERSION=3.2.2 PYTEST_VERSION=2.6.4
-    - TORNADO_VERSION=3.2.2 PYTEST_VERSION=2.5.2
 install:
     - pip install -q tornado==$TORNADO_VERSION pytest==$PYTEST_VERSION
     - python setup.py install
@@ -17,14 +17,12 @@ install:
 matrix:
   exclude:
     - python: 3.5
-      env: TORNADO_VERSION=3.2.2 PYTEST_VERSION=2.6.4
-    - python: 3.5
-      env: TORNADO_VERSION=3.2.2 PYTEST_VERSION=2.5.2
-    - python: 3.5
       env: TORNADO_VERSION=4.1 PYTEST_VERSION=2.6.4
     - python: 3.5
-      env: TORNADO_VERSION=4.1 PYTEST_VERSION=2.5.2
-    - python: 3.5
+      env: TORNADO_VERSION=4.1 PYTEST_VERSION=2.7.0
+    - python: 3.6
+      env: TORNADO_VERSION=4.1 PYTEST_VERSION=2.6.4
+    - python: 3.6
       env: TORNADO_VERSION=4.1 PYTEST_VERSION=2.7.0
 script:
     - py.test --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,4 @@ matrix:
     - python: 3.5
       env: TORNADO_VERSION=4.1 PYTEST_VERSION=2.7.0
 script:
-    - py.test --strict --cov=pytest_tornado/plugin.py --cov-report=term-missing
-after_success:
-  - coveralls
+    - py.test --strict

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -133,9 +133,7 @@ def io_loop(request):
 
     def _close():
         io_loop.clear_current()
-        if (not tornado.ioloop.IOLoop.initialized() or
-                io_loop is not tornado.ioloop.IOLoop.instance()):
-            io_loop.close(all_fds=True)
+        io_loop.close(all_fds=True)
 
     request.addfinalizer(_close)
     return io_loop
@@ -171,7 +169,7 @@ def http_server(request, io_loop, _unused_port):
         FixtureLookupError: tornado application fixture not found
     """
     http_app = request.getfuncargvalue(request.config.option.app_fixture)
-    server = tornado.httpserver.HTTPServer(http_app, io_loop=io_loop)
+    server = tornado.httpserver.HTTPServer(http_app)
     server.add_socket(_unused_port[0])
 
     def _stop():
@@ -189,12 +187,10 @@ def http_server(request, io_loop, _unused_port):
 def http_client(request, http_server):
     """Get an asynchronous HTTP client.
     """
-    client = tornado.httpclient.AsyncHTTPClient(io_loop=http_server.io_loop)
+    client = tornado.httpclient.AsyncHTTPClient()
 
     def _close():
-        if (not tornado.ioloop.IOLoop.initialized() or
-                client.io_loop is not tornado.ioloop.IOLoop.instance()):
-            client.close()
+        client.close()
 
     request.addfinalizer(_close)
     return client

--- a/pytest_tornado/test/test_server.py
+++ b/pytest_tornado/test/test_server.py
@@ -25,15 +25,15 @@ def _fetch(http_client, url):
         functools.partial(http_client.fetch, url))
 
 
-def test_http_server(http_server):
+def test_http_server(http_server, io_loop):
     status = {'done': False}
 
     def _done():
         status['done'] = True
-        http_server.io_loop.stop()
+        io_loop.stop()
 
-    http_server.io_loop.add_callback(_done)
-    http_server.io_loop.start()
+    io_loop.add_callback(_done)
+    io_loop.start()
 
     assert status['done']
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     keywords=('pytest py.test tornado async asynchronous '
               'testing unit tests plugin'),
     packages=find_packages(),
-    install_requires=['pytest', 'tornado'],
+    install_requires=['pytest', 'tornado>=4'],
     entry_points={
         'pytest11': ['tornado = pytest_tornado.plugin'],
     },


### PR DESCRIPTION
See http://www.tornadoweb.org/en/stable/releases/v5.0.0.html .
- Fixes use of `io_loop` keyword argument.
- Removes calls to `initialized()` and `instance()` as they are removed/deprecated.