### PR TITLE
Remove tornado 3 support

### DIFF
--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -15,26 +15,6 @@ if sys.version_info[:2] >= (3, 5):
 else:
     iscoroutinefunction = lambda f: False
 
-try:
-    with_timeout = tornado.gen.with_timeout
-except AttributeError:
-    from tornado.ioloop import IOLoop
-    from tornado.concurrent import Future, chain_future
-
-    # simplified version of 'with_timeout' from tornado 4.0
-    # to work with tornado 3
-    def with_timeout(timeout, future, io_loop=None):
-        result = Future()
-        chain_future(future, result)
-        if io_loop is None:
-            io_loop = IOLoop.current()
-        timeout_handle = io_loop.add_timeout(
-            timeout,
-            lambda: result.set_exception(TimeoutError("Timeout")))
-        future.add_done_callback(
-            lambda future: io_loop.remove_timeout(timeout_handle))
-        return result
-
 
 def _get_async_test_timeout():
     try:
@@ -111,7 +91,7 @@ def pytest_pyfunc_call(pyfuncitem):
             # Run this test function as a coroutine, until the timeout. When completed, stop the IOLoop
             # and reraise any exceptions
 
-            future_with_timeout = with_timeout(
+            future_with_timeout = tornado.gen.with_timeout(
                     datetime.timedelta(seconds=_timeout(pyfuncitem)),
                     future)
             io_loop.add_future(future_with_timeout, lambda f: io_loop.stop())


### PR DESCRIPTION
First I found that `TimeoutError` is not a standard python error in python 2, and then saw in `setup.py` the `tornado>=4` dependence.