### PR TITLE
pytest4 changed how markers work.  Updating plugin to play nice.

### DIFF
--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -168,7 +168,7 @@ def http_server(request, io_loop, _unused_port):
     Raises:
         FixtureLookupError: tornado application fixture not found
     """
-    http_app = request.getfuncargvalue(request.config.option.app_fixture)
+    http_app = request.getfixturevalue(request.config.option.app_fixture)
     server = tornado.httpserver.HTTPServer(http_app)
     server.add_socket(_unused_port[0])
 

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -92,7 +92,7 @@ def pytest_runtest_setup(item):
 
 @pytest.mark.tryfirst
 def pytest_pyfunc_call(pyfuncitem):
-    gen_test_mark = pyfuncitem.keywords.get('gen_test')
+    gen_test_mark = pyfuncitem.get_closest_marker('gen_test')
     if gen_test_mark:
         io_loop = pyfuncitem.funcargs.get('io_loop')
         run_sync = gen_test_mark.kwargs.get('run_sync', True)

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -70,7 +70,7 @@ def _argnames(func):
 
 def _timeout(item):
     default_timeout = item.config.getoption('async_test_timeout')
-    gen_test = item.get_marker('gen_test')
+    gen_test = item.get_closest_marker('gen_test')
     if gen_test:
         return gen_test.kwargs.get('timeout', default_timeout)
     return default_timeout

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with io.open(os.path.join(cwd, 'README.rst'), encoding='utf-8') as fd:
 
 setup(
     name='pytest-tornado',
-    version='0.5.0',
+    version='0.5.1',
     description=('A py.test plugin providing fixtures and markers '
                  'to simplify testing of asynchronous tornado applications.'),
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with io.open(os.path.join(cwd, 'README.rst'), encoding='utf-8') as fd:
 
 setup(
     name='pytest-tornado',
-    version='0.5.1',
+    version='0.5.0',
     description=('A py.test plugin providing fixtures and markers '
                  'to simplify testing of asynchronous tornado applications.'),
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with io.open(os.path.join(cwd, 'README.rst'), encoding='utf-8') as fd:
 
 setup(
     name='pytest-tornado',
-    version='0.5.1',
+    version='0.5.1a',
     description=('A py.test plugin providing fixtures and markers '
                  'to simplify testing of asynchronous tornado applications.'),
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with io.open(os.path.join(cwd, 'README.rst'), encoding='utf-8') as fd:
 
 setup(
     name='pytest-tornado',
-    version='0.5.1a',
+    version='0.5.1',
     description=('A py.test plugin providing fixtures and markers '
                  'to simplify testing of asynchronous tornado applications.'),
     long_description=long_description,


### PR DESCRIPTION
This change resolves issues such as:

RemovedInPytest4Warning: getfuncargvalue is deprecated, use getfixturevalue

and

RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly


For details on the reason these need to be updated, see https://docs.pytest.org/en/latest/mark.html#updating-code

Also bumped the minor version number from 0.5.0 to 0.5.1 - if that's wrong then feel free to revert or let me know and I will remove it.  Thanks!