### PR TITLE
Add CI for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 dist: xenial
 python:
     - 2.7
-    - 3.4
     - 3.5
     - 3.6
     - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
+dist: xenial
 python:
     - 2.7
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
 env:
     - TORNADO_VERSION=5.0 PYTEST_VERSION=4.0
     - TORNADO_VERSION=5.0.0 PYTEST_VERSION=3.6


### PR DESCRIPTION
We should run CI on Python 3.7 as well, as poitned out by @Jamim in #43.