### PR TITLE
Limit tornado version < 6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     keywords=('pytest py.test tornado async asynchronous '
               'testing unit tests plugin'),
     packages=find_packages(exclude=["tests.*", "tests"]),
-    install_requires=['pytest>=3.6', 'tornado>=4'],
+    install_requires=['pytest>=3.6', 'tornado>=4,<6'],
     entry_points={
         'pytest11': ['tornado = pytest_tornado.plugin'],
     },


### PR DESCRIPTION
We know that current version is incompatible with tornado 6, so make it explicit until it gets fixed.

This is in preparation for a 0.6.0 release, c.f. #45 