### PR TITLE
Restore coverage reporting from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,12 @@ env:
 install:
     - pip install -q tornado~=$TORNADO_VERSION pytest~=$PYTEST_VERSION
     - python setup.py install
-    - pip install pytest-cov coveralls
+    - pip install coverage coveralls
 script:
-    - py.test --strict
+    - coverage run --branch --source pytest_tornado.plugin -m pytest --strict
+    - coverage report -m
+after_success:
+    - coveralls
 
 jobs:
   include:


### PR DESCRIPTION
Hi there,

For some reason, when we use `pytest-cov` to run `pytest` with `--cov` option, it doesn't collect any data for `pytest_tornado/plugin.py` file.
So, we can use `coverage` directly as a workaround.