### PR TITLE
Add support for tornado version 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ after_success:
 jobs:
   include:
     - stage: deploy
+      python: 3.7
       deploy:
         provider: pypi
         distributions: sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
     - 3.6
     - 3.7
 env:
-    - TORNADO_VERSION=6.0 PYTEST_VERSION=4.3.1
+    - TORNADO_VERSION=6.0 PYTEST_VERSION=4.3
     - TORNADO_VERSION=5.0 PYTEST_VERSION=4.0
     - TORNADO_VERSION=5.0.0 PYTEST_VERSION=3.6
     - TORNADO_VERSION=5.0.0 PYTEST_VERSION=4.0.0
@@ -21,7 +21,7 @@ matrix:
   exclude:
     # Tornado 6 only supports Python >= 3.5
     - python: 2.7
-      env: TORNADO_VERSION=6.0 PYTEST_VERSION=4.3.1
+      env: TORNADO_VERSION=6.0 PYTEST_VERSION=4.3
 script:
     - coverage run --branch --source pytest_tornado.plugin -m pytest --strict
     - coverage report -m

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - 3.6
     - 3.7
 env:
+    - TORNADO_VERSION=6.0 PYTEST_VERSION=4.3.1
     - TORNADO_VERSION=5.0 PYTEST_VERSION=4.0
     - TORNADO_VERSION=5.0.0 PYTEST_VERSION=3.6
     - TORNADO_VERSION=5.0.0 PYTEST_VERSION=4.0.0
@@ -16,6 +17,11 @@ install:
     - pip install -q tornado~=$TORNADO_VERSION pytest~=$PYTEST_VERSION
     - python setup.py install
     - pip install coverage coveralls
+matrix:
+  exclude:
+    # Tornado 6 only supports Python >= 3.5
+    - python: 2.7
+      env: TORNADO_VERSION=6.0 PYTEST_VERSION=4.3.1
 script:
     - coverage run --branch --source pytest_tornado.plugin -m pytest --strict
     - coverage report -m

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     keywords=('pytest py.test tornado async asynchronous '
               'testing unit tests plugin'),
     packages=find_packages(exclude=["tests.*", "tests"]),
-    install_requires=['pytest>=3.6', 'tornado>=4,<6'],
+    install_requires=['pytest>=3.6', 'tornado>=4.1'],
     entry_points={
         'pytest11': ['tornado = pytest_tornado.plugin'],
     },

--- a/test/test_async.py
+++ b/test/test_async.py
@@ -7,7 +7,7 @@ from tornado.ioloop import TimeoutError
 
 @gen.coroutine
 def dummy_coroutine(io_loop):
-    yield gen.Task(io_loop.add_callback)
+    yield gen.sleep(0)
     raise gen.Return(True)
 
 
@@ -50,26 +50,26 @@ def test_gen_test_swallows_exceptions(io_loop):
 @pytest.mark.gen_test
 def test_generator_raises(io_loop):
     with pytest.raises(ZeroDivisionError):
-        yield gen.Task(io_loop.add_callback)
+        yield gen.sleep(0)
         1 / 0
 
 
 @pytest.mark.gen_test
 def test_explicit_gen_test_marker(request, io_loop):
-    yield gen.Task(io_loop.add_callback)
+    yield gen.sleep(0)
     assert 'gen_test' in request.keywords
 
 
 @pytest.mark.gen_test(timeout=2.1)
 def test_gen_test_marker_with_params(request, io_loop):
-    yield gen.Task(io_loop.add_callback)
+    yield gen.sleep(0)
     assert request.node.get_closest_marker('gen_test').kwargs['timeout'] == 2.1
 
 
 @pytest.mark.xfail(raises=TimeoutError)
 @pytest.mark.gen_test(timeout=0.1)
 def test_gen_test_with_timeout(io_loop):
-    yield gen.Task(io_loop.add_timeout, io_loop.time() + 1)
+    yield gen.sleep(1)
 
 
 def test_sync_tests_no_gen_test_marker(request):
@@ -85,5 +85,5 @@ class TestClass:
     @pytest.mark.gen_test
     def test_generator_raises(self, io_loop):
         with pytest.raises(ZeroDivisionError):
-            yield gen.Task(io_loop.add_callback)
+            yield gen.sleep(0)
             1 / 0

--- a/test/test_async_await.py
+++ b/test/test_async_await.py
@@ -2,7 +2,7 @@ import pytest
 from tornado import gen
 
 async def dummy_native_coroutine(io_loop):
-    await gen.Task(io_loop.add_callback)
+    await gen.sleep(0)
     return True
 
 

--- a/test/test_fixtures.py
+++ b/test/test_fixtures.py
@@ -7,7 +7,7 @@ _used_fixture = False
 
 @gen.coroutine
 def dummy(io_loop):
-    yield gen.Task(io_loop.add_callback)
+    yield gen.sleep(0)
     raise gen.Return(True)
 
 

--- a/test/test_param.py
+++ b/test/test_param.py
@@ -54,7 +54,7 @@ def test_param_fixture(_dummy):
     ('2+4', 6),
 ])
 def test_gen_test_parametrize(io_loop, input, expected):
-    yield gen.Task(io_loop.add_callback)
+    yield gen.sleep(0)
     assert eval(input) == expected
 
 
@@ -64,11 +64,11 @@ def test_gen_test_parametrize(io_loop, input, expected):
 ])
 @pytest.mark.gen_test
 def test_gen_test_fixture_any_order(input, io_loop, expected):
-    yield gen.Task(io_loop.add_callback)
+    yield gen.sleep(0)
     assert eval(input) == expected
 
 
 @pytest.mark.gen_test
 def test_gen_test_param_fixture(io_loop, _dummy):
-    yield gen.Task(io_loop.add_callback)
+    yield gen.sleep(0)
     assert _dummy in DUMMY_PARAMS


### PR DESCRIPTION
- Adds CI for tornado 6.
- Replaces deprecated API calls.
- The new `gen.sleep` was added in 4.1, so that is the new lower requirement for the tornado dependency.