### PR TITLE
Support for HTTPS testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Cert for testing
+testcert.pem

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - TORNADO_VERSION=4.1.0 PYTEST_VERSION=3.6.4
 install:
     - pip install -q tornado~=$TORNADO_VERSION pytest~=$PYTEST_VERSION
+    - pip install PyOpenSSL  # used to create a cert for testing
     - python setup.py install
     - pip install coverage coveralls
 matrix:
@@ -23,6 +24,7 @@ matrix:
     - python: 2.7
       env: TORNADO_VERSION=6.0 PYTEST_VERSION=4.3
 script:
+    - python test/create_cert.py --cert test/testcert.pem
     - coverage run --branch --source pytest_tornado.plugin -m pytest --strict
     - coverage report -m
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,28 @@ http_client
     get an asynchronous HTTP client
 
 
+There is also the possibility to test applications with HTTPS.
+For running a server with HTTPS you need a certificate.
+
+https_port
+    Get a port used by the test server.
+
+secure_base_url
+    Get an absolute base url for the test server.
+    For example ``https://localhost:28598``
+
+https_server
+    Start a tornado HTTPS server. You must create an ``app`` fixture,
+    which returns the `tornado.web.Application`_ to be tested, and
+    an ``ssl_options`` fixture which returns the SSL options for the
+    `tornado.httpserver.HTTPServer`_.
+
+https_client
+    Get an asynchronous HTTP client.
+    In case your test uses an self-signed certificate you can set
+    ``verify=False`` on the fetch method.
+
+
 Show fixtures provided by the plugin::
 
     py.test --fixtures
@@ -102,7 +124,7 @@ setting an ``ASYNC_TEST_TIMEOUT`` environment variable,
     def test_tornado(http_client):
         yield http_client.fetch('http://www.tornadoweb.org/')
 
-The mark can also receive a run_sync flag, which if turned off will, instead of running the test synchronously, will add it as a coroutine and run the IOLoop (until the timeout). For instance, this allows to test things on both a client and a server at the same time. 
+The mark can also receive a run_sync flag, which if turned off will, instead of running the test synchronously, will add it as a coroutine and run the IOLoop (until the timeout). For instance, this allows to test things on both a client and a server at the same time.
 
 .. code-block:: python
 
@@ -118,6 +140,7 @@ Show markers provided by the plugin::
 
 
 .. _py.test: http://pytest.org/
+.. _`tornado.httpserver.HTTPServer`: https://www.tornadoweb.org/en/latest/httpserver.html#http-server
 .. _`tornado.ioloop.IOLoop`: http://tornado.readthedocs.org/en/latest/ioloop.html#ioloop-objects
 .. _`tornado.web.Application`: http://tornado.readthedocs.org/en/latest/web.html#application-configuration
 .. _`tornado.gen`: http://tornado.readthedocs.org/en/latest/gen.html

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,10 @@ http_port
     get a port used by the test server
 
 base_url
-    get an absolute base url for the test server,
-    for example, ``http://localhost:59828``
+    Get an absolute base url for the test server,
+    for example ``http://localhost:59828``.
+    Can also be used in a test with HTTPS fixture and will then return
+    a corresponding url, for example ``http://localhost:48372``.
 
 http_server
     start a tornado HTTP server, you must create an ``app`` fixture,
@@ -78,10 +80,6 @@ For running a server with HTTPS you need a certificate.
 
 https_port
     Get a port used by the test server.
-
-secure_base_url
-    Get an absolute base url for the test server.
-    For example ``https://localhost:28598``
 
 https_server
     Start a tornado HTTPS server. You must create an ``app`` fixture,

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -29,6 +29,8 @@ def pytest_addoption(parser):
                      help='timeout in seconds before failing the test')
     parser.addoption('--app-fixture', default='app',
                      help='fixture name returning a tornado application')
+    parser.addoption('--ssl-options-fixture', default='ssl_options',
+                     help='fixture name returning a certificate configuration')
 
 
 def pytest_configure(config):
@@ -192,15 +194,8 @@ def https_server(request, io_loop, _unused_port):
         FixtureLookupError: tornado application fixture not found
     """
     http_app = request.getfixturevalue(request.config.option.app_fixture)
-    ssl_options = {}
-    # I dont know to get server cert & key from user 
-    """
-    http_server = HTTPServer(application, ssl_options={
-            "certfile": settings["server_certfile"],
-            "keyfile": settings["server_keyfile"]
-            })
-    """
-    server = tornado.httpserver.HTTPServer(http_app, ssl_options=ssl_options, io_loop=io_loop)
+    ssl_options = request.getfixturevalue(request.config.option.ssl_options_fixture)
+    server = tornado.httpserver.HTTPServer(http_app, ssl_options=ssl_options)
     server.add_socket(_unused_port[0])
 
     def _stop():

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -191,7 +191,7 @@ def https_server(request, io_loop, _unused_port):
     Raises:
         FixtureLookupError: tornado application fixture not found
     """
-    http_app = request.getfuncargvalue(request.config.option.app_fixture)
+    http_app = request.getfixturevalue(request.config.option.app_fixture)
     ssl_options = {}
     # I dont know to get server cert & key from user 
     """

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -215,7 +215,7 @@ def https_server(request, io_loop, _unused_port):
 
 
 @pytest.fixture
-def https_client(request, http_server):
+def https_client(request, https_server):
     """Get an asynchronous HTTPS client.
     """
     # How does on get ca_certs from the user

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -146,17 +146,14 @@ def https_port(_unused_port):
 
 
 @pytest.fixture
-def base_url(http_port):
+def base_url(request):
     """Create an absolute base url (scheme://host:port)
     """
-    return 'http://localhost:%s' % http_port
+    fixturenames = request.fixturenames
+    if 'https_port' in fixturenames or 'https_client' in fixturenames or 'https_server' in fixturenames:
+        return 'https://localhost:%s' % request.getfixturevalue('https_port')
 
-
-@pytest.fixture
-def secure_base_url(https_port):
-    """Create an absolute base url (scheme://host:port)
-    """
-    return 'https://localhost:%s' % https_port
+    return 'http://localhost:%s' % request.getfixturevalue('http_port')
 
 
 @pytest.fixture

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -200,9 +200,9 @@ def https_server(request, io_loop, _unused_port):
     Raises:
         FixtureLookupError: tornado application fixture not found
     """
-    http_app = request.getfixturevalue(request.config.option.app_fixture)
+    https_app = request.getfixturevalue(request.config.option.app_fixture)
     ssl_options = request.getfixturevalue(request.config.option.ssl_options_fixture)
-    server = tornado.httpserver.HTTPServer(http_app, ssl_options=ssl_options)
+    server = tornado.httpserver.HTTPServer(https_app, ssl_options=ssl_options)
     server.add_socket(_unused_port[0])
 
     def _stop():

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -153,6 +153,13 @@ def base_url(http_port):
 
 
 @pytest.fixture
+def secure_base_url(https_port):
+    """Create an absolute base url (scheme://host:port)
+    """
+    return 'https://localhost:%s' % https_port
+
+
+@pytest.fixture
 def http_server(request, io_loop, _unused_port):
     """Start a tornado HTTP server.
 

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -142,7 +142,7 @@ def http_port(_unused_port):
 def https_port(_unused_port):
     """Get a port used by the test server.
     """
-    return _unused_port[0]
+    return _unused_port[1]
 
 
 @pytest.fixture
@@ -191,7 +191,7 @@ def http_client(request, http_server):
 
 
 @pytest.fixture
-def https_server(request, io_loop, https_port):
+def https_server(request, io_loop, _unused_port):
     """Start a tornado HTTPS server.
 
     You must create an `app` fixture, which returns
@@ -203,7 +203,7 @@ def https_server(request, io_loop, https_port):
     http_app = request.getfixturevalue(request.config.option.app_fixture)
     ssl_options = request.getfixturevalue(request.config.option.ssl_options_fixture)
     server = tornado.httpserver.HTTPServer(http_app, ssl_options=ssl_options)
-    server.add_socket(https_port)
+    server.add_socket(_unused_port[0])
 
     def _stop():
         server.stop()

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -139,6 +139,13 @@ def http_port(_unused_port):
 
 
 @pytest.fixture
+def https_port(_unused_port):
+    """Get a port used by the test server.
+    """
+    return _unused_port[0]
+
+
+@pytest.fixture
 def base_url(http_port):
     """Create an absolute base url (scheme://host:port)
     """
@@ -184,7 +191,7 @@ def http_client(request, http_server):
 
 
 @pytest.fixture
-def https_server(request, io_loop, _unused_port):
+def https_server(request, io_loop, https_port):
     """Start a tornado HTTPS server.
 
     You must create an `app` fixture, which returns
@@ -196,7 +203,7 @@ def https_server(request, io_loop, _unused_port):
     http_app = request.getfixturevalue(request.config.option.app_fixture)
     ssl_options = request.getfixturevalue(request.config.option.ssl_options_fixture)
     server = tornado.httpserver.HTTPServer(http_app, ssl_options=ssl_options)
-    server.add_socket(_unused_port[0])
+    server.add_socket(https_port)
 
     def _stop():
         server.stop()

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -219,12 +219,10 @@ def https_client(request, https_server):
     """Get an asynchronous HTTPS client.
     """
     # How does on get ca_certs from the user
-    client = tornado.httpclient.AsyncHTTPClient(ca_certs=ca_certs, io_loop=https_server.io_loop)
+    client = tornado.httpclient.AsyncHTTPClient()
 
     def _close():
-        if (not tornado.ioloop.IOLoop.initialized() or
-                client.io_loop is not tornado.ioloop.IOLoop.instance()):
-            client.close()
+        client.close()
 
     request.addfinalizer(_close)
     return client

--- a/test/create_cert.py
+++ b/test/create_cert.py
@@ -58,13 +58,16 @@ def createCertificate(path):
 	with open(path, "wt") as certfile:
 		certfile.write(certcontext.decode())
 
-	with NamedTemporaryFile(mode="wb") as randfile:
-		randfile.write(randomBytes(512))
+	try:
+		with NamedTemporaryFile(mode="wb", delete=False) as randfile:
+			randfile.write(randomBytes(512))
 
-		command = u"openssl dhparam -rand {tempfile} 512 >> {target}".format(
-			tempfile=randfile.name, target=path
-		)
+			command = u"openssl dhparam -rand {tempfile} 512 >> {target}".format(
+				tempfile=randfile.name, target=path
+			)
 		os.system(command)
+	finally:
+		os.remove(randfile.name)
 
 
 def randomBytes(length):

--- a/test/create_cert.py
+++ b/test/create_cert.py
@@ -8,7 +8,6 @@ Source: https://github.com/opsi-org/python-opsi/blob/stable/OPSI/Util/Task/Certi
 import argparse
 import os
 import random
-import shutil
 import socket
 from tempfile import NamedTemporaryFile
 

--- a/test/create_cert.py
+++ b/test/create_cert.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+Create a cert with pyOpenSSL for tests.
+
+Heavily based on python-opsi's OPSI.Util.Task.Certificate.
+Source: https://github.com/opsi-org/python-opsi/blob/stable/OPSI/Util/Task/Certificate.py
+"""
+import argparse
+import os
+import random
+import shutil
+import socket
+from tempfile import NamedTemporaryFile
+
+from OpenSSL import crypto
+
+try:
+	import secrets
+except ImportError:
+	secrets = None
+
+
+def createCertificate(path):
+	"""
+	Creates a certificate.
+	"""
+	cert = crypto.X509()
+	cert.get_subject().C = "DE"  # Country
+	cert.get_subject().ST = "HE"  # State
+	cert.get_subject().L = "Wiesbaden"  # Locality
+	cert.get_subject().O = "pytest-tornado"  # Organisation
+	cert.get_subject().OU = "Testing Department"  # organisational unit
+	cert.get_subject().CN = socket.getfqdn()  # common name
+
+	# As described in RFC5280 this value is required and must be a
+	# positive and unique integer.
+	# Source: http://tools.ietf.org/html/rfc5280#page-19
+	cert.set_serial_number(random.randint(0, pow(2, 16)))
+
+	cert.gmtime_adj_notBefore(0)
+	cert.gmtime_adj_notAfter(60 * 60)  # Valid 1 hour
+
+	k = crypto.PKey()
+	k.generate_key(crypto.TYPE_RSA, 2048)
+
+	cert.set_issuer(cert.get_subject())
+	cert.set_pubkey(k)
+	cert.set_version(2)
+
+	cert.sign(k, 'sha512')
+
+	certcontext = b"".join(
+		(
+			crypto.dump_certificate(crypto.FILETYPE_PEM, cert),
+			crypto.dump_privatekey(crypto.FILETYPE_PEM, k)
+		)
+	)
+
+	with open(path, "wt") as certfile:
+		certfile.write(certcontext.decode())
+
+	with NamedTemporaryFile(mode="wb") as randfile:
+		randfile.write(randomBytes(512))
+
+		command = u"openssl dhparam -rand {tempfile} 512 >> {target}".format(
+			tempfile=randfile.name, target=path
+		)
+		os.system(command)
+
+
+def randomBytes(length):
+	"""
+	Return _length_ random bytes.
+
+	:rtype: bytes
+	"""
+	if secrets:
+		return secrets.token_bytes(512)
+	else:
+		return os.urandom(512)
+
+
+if __name__ == '__main__':
+	parser = argparse.ArgumentParser(description='Create certificate for testing')
+	parser.add_argument('--cert', dest='cert', default="testcert.pem",
+	                    help='Name of the certificate')
+
+	args = parser.parse_args()
+	createCertificate(args.cert)

--- a/test/test_https_support.py
+++ b/test/test_https_support.py
@@ -1,0 +1,36 @@
+import os
+import ssl
+import pytest
+import tornado.web
+
+
+class MainHandler(tornado.web.RequestHandler):
+    def get(self):
+        self.write("Hello, world")
+
+
+@pytest.fixture
+def ssl_options():
+    cert_file = os.path.join(os.path.dirname(__file__), 'testcert.pem')
+    if not os.path.exists(cert_file):
+        pytest.skip("Missing cert file {!r}")
+    key_file = os.path.join(os.path.dirname(__file__), 'testcert.pem')
+    if not os.path.exists(key_file):
+        pytest.skip("Missing key file {!r}")
+
+    ssl_context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH, cafile=None, capath=None, cadata=None)
+    ssl_context.load_cert_chain(cert_file, keyfile=key_file)
+    return ssl_context
+
+
+@pytest.fixture
+def app():
+    return tornado.web.Application([
+        (r"/", MainHandler),
+    ])
+
+
+@pytest.mark.gen_test
+def test_hello_world(https_client, secure_base_url):
+    response = yield https_client.fetch(secure_base_url, validate_cert=False)
+    assert response.code == 200

--- a/test/test_https_support.py
+++ b/test/test_https_support.py
@@ -31,6 +31,20 @@ def app():
 
 
 @pytest.mark.gen_test
-def test_hello_world(https_client, secure_base_url):
-    response = yield https_client.fetch(secure_base_url, validate_cert=False)
+def test_hello_world(https_client, base_url):
+    response = yield https_client.fetch(base_url, validate_cert=False)
     assert response.code == 200
+
+
+def test_base_url_is_https_with_https_client(https_client, base_url):
+    assert base_url.startswith('https://')
+
+
+
+def test_base_url_is_https_with_https_port(https_port, base_url):
+    assert base_url.startswith('https://')
+
+
+
+def test_base_url_is_https_with_https_server(https_server, base_url):
+    assert base_url.startswith('https://')

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -68,3 +68,7 @@ def test_get_url_with_path(http_client, base_url):
 def test_http_client_raises_on_404(http_client, base_url):
     with pytest.raises(tornado.httpclient.HTTPError):
         yield http_client.fetch('%s/bar' % base_url)
+
+
+def test_base_url_default_is_http(base_url):
+    assert base_url.startswith('http://')


### PR DESCRIPTION
This adds support for testing with HTTPS.
Based on the work of @judeaugustinej in PR #22 to fix #21.

It adds fixtures `https_port`, `https_server`, `https_client` and `secure_base_url`.

Even though it works I'd like things to be easier to use in regard of `base_url`, because this introduces another fixture `secure_base_url`. I'd like to have only the `base_url` fixture available but am currently not sure if or how this could be implemented.
Feedback in this regard is more than welcome!

Options for SSL have to be given through an fixture `ssl_options` in a way like currently `app` is used.