### PR TITLE
plugin: Put custom CLI options in "tornado" group

### DIFF
--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -24,13 +24,14 @@ def _get_async_test_timeout():
 
 
 def pytest_addoption(parser):
-    parser.addoption('--async-test-timeout', type=float,
-                     default=_get_async_test_timeout(),
-                     help='timeout in seconds before failing the test')
-    parser.addoption('--app-fixture', default='app',
-                     help='fixture name returning a tornado application')
-    parser.addoption('--ssl-options-fixture', default='ssl_options',
-                     help='fixture name returning a certificate configuration')
+    tornado_group = parser.getgroup('tornado options')
+    tornado_group.addoption('--async-test-timeout', type=float,
+                            default=_get_async_test_timeout(),
+                            help='timeout in seconds before failing the test')
+    tornado_group.addoption('--app-fixture', default='app',
+                            help='fixture name returning a tornado application')
+    tornado_group.addoption('--ssl-options-fixture', default='ssl_options',
+                            help='fixture name returning a certificate configuration')
 
 
 def pytest_configure(config):


### PR DESCRIPTION
Previously, the command-line options were added to the default group, labelled "custom options" by Pytest. This commit puts the options in a group labelled "tornado options", separating them from other options in order to make it clear where they come from. This is especially useful in environments where multiple plugins are used.