### PR TITLE
Supporting Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - TORNADO_VERSION=4.3.0 PYTEST_VERSION=3.6
     - TORNADO_VERSION=4.1.0 PYTEST_VERSION=3.6.4
 install:
-    - pip install -q tornado~=$TORNADO_VERSION pytest~=$PYTEST_VERSION
+    - pip install tornado~=$TORNADO_VERSION pytest~=$PYTEST_VERSION
     - pip install PyOpenSSL  # used to create a cert for testing
     - python setup.py install
     - pip install coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
     # Tornado 6 only supports Python >= 3.5
     - python: 2.7
       env: TORNADO_VERSION=6.0 PYTEST_VERSION=4.3
+    # Pytest 4.0.0 requires an version of attrs that does not work with Python 3.8.
+    - python: 3.8
+      env: TORNADO_VERSION=5.0.0 PYTEST_VERSION=4.0.0
 script:
     - python test/create_cert.py --cert test/testcert.pem
     - coverage run --branch --source pytest_tornado.plugin -m pytest --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     # Tornado 6 only supports Python >= 3.5
     - python: 2.7
       env: TORNADO_VERSION=6.0 PYTEST_VERSION=4.3
-    # Pytest 4.0.0 requires an version of attrs that does not work with Python 3.8.
+    # Pytest 4.0.0 requires a version of attrs that does not work with Python 3.8.
     - python: 3.8
       env: TORNADO_VERSION=5.0.0 PYTEST_VERSION=4.0.0
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
 env:
     - TORNADO_VERSION=6.0 PYTEST_VERSION=4.3
     - TORNADO_VERSION=5.0 PYTEST_VERSION=4.0


### PR DESCRIPTION
Python 3.8 has been released into the wild.
This adds it to the Travis test matrix.

Unfortunately we have to disable running with Tornado 5.0.0 and pytest 4.0.0 as this version depends on a version of attrs that breaks with Python 3.8.
Later versions have this fixed.