### PR TITLE
Fix pytest deprecation warning for pytest version greater than 5.4

### DIFF
--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -3,6 +3,7 @@ import sys
 import types
 import inspect
 import datetime
+import packaging
 import pytest
 import tornado
 import tornado.gen
@@ -14,6 +15,8 @@ if sys.version_info[:2] >= (3, 5):
     iscoroutinefunction = inspect.iscoroutinefunction
 else:
     iscoroutinefunction = lambda f: False
+
+_PYTEST_VERSION = packaging.version.parse(pytest.__version__)
 
 
 def _get_async_test_timeout():
@@ -67,7 +70,10 @@ def _timeout(item):
 @pytest.mark.tryfirst
 def pytest_pycollect_makeitem(collector, name, obj):
     if collector.funcnamefilter(name) and inspect.isgeneratorfunction(obj):
-        item = pytest.Function(name, parent=collector)
+        if _PYTEST_VERSION >= packaging.version.parse("5.4.0"):
+            item = pytest.Function.from_parent(collector, name=name)
+        else:
+            item = pytest.Function(name, parent=collector)
         if 'gen_test' in item.keywords:
             return list(collector._genfunctions(name, obj))
 

--- a/pytest_tornado/plugin.py
+++ b/pytest_tornado/plugin.py
@@ -3,7 +3,7 @@ import sys
 import types
 import inspect
 import datetime
-import packaging
+import pkg_resources
 import pytest
 import tornado
 import tornado.gen
@@ -16,7 +16,7 @@ if sys.version_info[:2] >= (3, 5):
 else:
     iscoroutinefunction = lambda f: False
 
-_PYTEST_VERSION = packaging.version.parse(pytest.__version__)
+_PYTEST_VERSION = pkg_resources.parse_version(pytest.__version__)
 
 
 def _get_async_test_timeout():
@@ -70,7 +70,7 @@ def _timeout(item):
 @pytest.mark.tryfirst
 def pytest_pycollect_makeitem(collector, name, obj):
     if collector.funcnamefilter(name) and inspect.isgeneratorfunction(obj):
-        if _PYTEST_VERSION >= packaging.version.parse("5.4.0"):
+        if _PYTEST_VERSION >= pkg_resources.parse_version("5.4.0"):
             item = pytest.Function.from_parent(collector, name=name)
         else:
             item = pytest.Function(name, parent=collector)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     keywords=('pytest py.test tornado async asynchronous '
               'testing unit tests plugin'),
     packages=find_packages(exclude=["tests.*", "tests"]),
-    install_requires=['pytest>=3.6', 'tornado>=4.1'],
+    install_requires=['pytest>=3.6', 'tornado>=4.1', 'setuptools'],
     entry_points={
         'pytest11': ['tornado = pytest_tornado.plugin'],
     },


### PR DESCRIPTION
Running the test using pytest version 5.4 or newer gives the following deprecation warning from pytest

```
pytest_tornado/plugin.py:70: 17 tests with warnings
  /Users/henriknf/local/src/pytest-tornado/pytest_tornado/plugin.py:70: PytestDeprecationWarning: direct construction of Function has been deprecated, please use Function.from_parent
    item = pytest.Function(name, parent=collector)
```

Here is a fix that is also backward compatible with older versions of `pytest`